### PR TITLE
fix: enable fetch_iterable_type_support for Cloudflare Workers SSR

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,7 +2,14 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "critical-mass",
   "compatibility_date": "2026-01-15",
-  "compatibility_flags": ["nodejs_compat"],
+  "compatibility_flags": [
+    "nodejs_compat",
+    // Required: with nodejs_compat (process v2 enabled by default after
+    // 2025-09-15), Astro detects Node and returns Response bodies as async
+    // iterables. Workers' Response only handles those when this flag is on.
+    // Defaults true after 2026-02-19; we set explicitly for our compat date.
+    "fetch_iterable_type_support"
+  ],
   "d1_databases": [
     {
       "binding": "DB",


### PR DESCRIPTION
## Summary
SSR pages were returning literal `[object Object]` bodies on Cloudflare Workers. The `nodejs_compat` flag (combined with our compatibility date `2026-01-15`) auto-enables `enable_nodejs_process_v2` from `2025-09-15`, which makes Astro's `isNode` detection return true and switches to its async-iterable Response path. Workers' Response constructor only consumes async iterables when `fetch_iterable_type_support` is enabled — and that auto-enables only from `2026-02-19`, leaving us in the gap. Setting the flag explicitly closes it.

## Testing
- `bun run build` clean, `bun run lint` clean
- `wrangler dev` returns full HTML on `/pt`, `/_emdash/admin`, etc.

## References
- Astro #15434 (closed as upstream)
- Cloudflare Workers compatibility flags docs