### PR TITLE
feat: redirect /admin to /_emdash/admin

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -40,6 +40,9 @@ export default defineConfig({
   adapter: cloudflare({
     imageService: "compile",
   }),
+  redirects: {
+    "/admin": "/_emdash/admin",
+  },
   i18n: {
     locales: [...locales],
     defaultLocale: baseLocale,


### PR DESCRIPTION
## Summary
- Adds an Astro `redirects` entry mapping `/admin` → `/_emdash/admin` so editors can use the shorter URL.