### PR TITLE
feat: send Emdash auth emails via Cloudflare Email Service

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 import emdash from "emdash/astro";
 import { baseLocale, locales } from "./src/paraglide/runtime";
+import { emailCloudflare } from "./src/plugins/email-cloudflare";
 
 // https://astro.build/config
 export default defineConfig({
@@ -33,6 +34,12 @@ export default defineConfig({
     emdash({
       database: d1({ binding: "DB" }),
       storage: r2({ binding: "MEDIA" }),
+      plugins: [
+        emailCloudflare({
+          from: "auth@admin.massacritica.pt",
+          fromName: "Massa Crítica",
+        }),
+      ],
     }),
     sitemap(),
   ],

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,3 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+/// <reference types="@cloudflare/workers-types/latest" />

--- a/src/plugins/email-cloudflare.ts
+++ b/src/plugins/email-cloudflare.ts
@@ -1,0 +1,93 @@
+/**
+ * Cloudflare Email Service provider for Emdash CMS.
+ *
+ * Registers the exclusive `email:deliver` hook so Emdash auth (magic links,
+ * invites, recovery) sends through the `SEND_EMAIL` Workers binding.
+ *
+ * Requires `send_email` binding in wrangler.jsonc and the sending domain
+ * onboarded via the Cloudflare dashboard (Email Sending → Onboard Domain).
+ *
+ * @see https://developers.cloudflare.com/email-service/api/send-emails/workers-api/
+ */
+
+import type { PluginContext, PluginDescriptor, ResolvedPlugin } from "emdash";
+import { definePlugin } from "emdash";
+
+interface SendEmailBinding {
+  send(message: {
+    to: string | string[];
+    from: string | { email: string; name: string };
+    subject: string;
+    html?: string;
+    text?: string;
+  }): Promise<{ messageId: string }>;
+}
+
+interface EmailDeliverEvent {
+  message: { to: string; subject: string; text: string; html?: string };
+  source: string;
+}
+
+export interface EmailCloudflareConfig {
+  /** Sender address. Must match an `allowed_sender_addresses` entry on the binding (if set). */
+  from: string;
+  /** Optional display name shown alongside the sender address. */
+  fromName?: string;
+  /** Binding name from wrangler.jsonc. Defaults to `SEND_EMAIL`. */
+  binding?: string;
+}
+
+export function emailCloudflare(config: EmailCloudflareConfig): PluginDescriptor {
+  return {
+    id: "email-cloudflare",
+    version: "1.0.0",
+    format: "native",
+    entrypoint: "@/plugins/email-cloudflare",
+    options: { ...config },
+    capabilities: ["email:provide"],
+  };
+}
+
+export function createPlugin(config: EmailCloudflareConfig): ResolvedPlugin {
+  const bindingName = config.binding ?? "SEND_EMAIL";
+  const from = config.fromName ? { email: config.from, name: config.fromName } : config.from;
+
+  return definePlugin({
+    id: "email-cloudflare",
+    version: "1.0.0",
+    capabilities: ["email:provide"],
+    hooks: {
+      "email:deliver": {
+        exclusive: true,
+        handler: async (event: EmailDeliverEvent, ctx: PluginContext): Promise<void> => {
+          const { env } = await import("cloudflare:workers");
+          const binding = (env as Record<string, unknown>)[bindingName] as
+            | SendEmailBinding
+            | undefined;
+
+          if (!binding) {
+            throw new Error(
+              `[email-cloudflare] Worker binding "${bindingName}" not found. ` +
+                "Add it to wrangler.jsonc under `send_email` and redeploy.",
+            );
+          }
+
+          const { message, source } = event;
+          const result = await binding.send({
+            to: message.to,
+            from,
+            subject: message.subject,
+            text: message.text,
+            html: message.html,
+          });
+
+          ctx.log.info("Email delivered via Cloudflare Email Service", {
+            to: message.to,
+            source,
+            messageId: result.messageId,
+          });
+        },
+      },
+    },
+  });
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -24,5 +24,12 @@
       "bucket_name": "massacritica-media",
       "remote": true
     }
+  ],
+  "send_email": [
+    {
+      "name": "SEND_EMAIL",
+      "allowed_sender_addresses": ["auth@admin.massacritica.pt"],
+      "remote": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary
Wires Cloudflare Email Service (Email Sending public beta) as the email transport for Emdash auth so magic-link login works for the CMS at `/_emdash/admin`. Adds a local Emdash plugin that registers the exclusive `email:deliver` hook and sends via the `SEND_EMAIL` Workers binding, with the sender locked to `auth@admin.massacritica.pt` via `allowed_sender_addresses`.

## Test plan
- [x] Deploy and try "Sign in with email" at `/_emdash/admin`; magic link arrives from `auth@admin.massacritica.pt` and authenticates.
- [x] Worker tail (`wrangler tail`) shows the `Email delivered via Cloudflare Email Service` log with a `messageId` on success, or a clear error otherwise.