### PR TITLE
fix: set Emdash siteUrl to canonical massacritica.pt origin

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -32,6 +32,7 @@ export default defineConfig({
     // In local dev, the Cloudflare Vite plugin emulates D1 with local SQLite
     // and R2 with local filesystem automatically.
     emdash({
+      siteUrl: "https://massacritica.pt",
       database: d1({ binding: "DB" }),
       storage: r2({ binding: "MEDIA" }),
       plugins: [


### PR DESCRIPTION
## Summary
Pass `siteUrl: "https://massacritica.pt"` to the `emdash()` integration so the public origin no longer falls back to the incoming request host. Without this, accessing the admin via `critical-mass.afonsojramos.workers.dev` produced magic-link verify URLs pointing at the workers.dev preview instead of the canonical domain — also affecting WebAuthn `rpId` and CSRF origin checks.

## Test plan
- [ ] Deploy and request a magic link from the admin
- [ ] Confirm the email's verify URL uses `https://massacritica.pt/_emdash/api/auth/magic-link/verify?token=…`
- [ ] Confirm login still works when the admin is accessed from `massacritica.pt`